### PR TITLE
Fix: Populate PostFactory definition for required fields

### DIFF
--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -2,7 +2,9 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Post>
@@ -16,8 +18,14 @@ class PostFactory extends Factory
      */
     public function definition(): array
     {
+        $title = $this->faker->sentence;
         return [
-            //
+            'user_id' => User::factory(),
+            'title' => $title,
+            'slug' => Str::slug($title),
+            'content' => $this->faker->paragraphs(3, true),
+            'published_at' => $this->faker->optional()->dateTimeThisYear(),
+            // Add any other fields that are required or should have defaults
         ];
     }
 }


### PR DESCRIPTION
Updated `database/factories/PostFactory.php` to provide default values for `user_id`, `title`, `slug`, `content`, and `published_at`. This resolves the NOT NULL constraint violation encountered when running tests that create Post instances using the factory.